### PR TITLE
Added BUTTON_COLOUR_DARKEN_5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ export const LINK_ACTIVE_COLOUR = LIGHT_BLUE;
 export const LINK_HOVER_COLOUR = LIGHT_BLUE;
 export const LINK_VISITED_COLOUR = "#4c2c92";
 export const BUTTON_COLOUR = "#00823b";
+export const BUTTON_COLOUR_DARKEN_5 = '#00692f'; // darken(#00823b, 5%)
 export const BUTTON_COLOUR_DARKEN_15 = "#003618"; //darken(#00823b, 15%)
 export const FOCUS_COLOUR = YELLOW;
 export const TEXT_COLOUR = BLACK;


### PR DESCRIPTION
Added **BUTTON_COLOUR_DARKEN_5** based on `$govuk-button-hover-color` at [AlphaGov UK Front End Colours SASS](https://github.com/alphagov/govuk-frontend/blob/3c683e8fb7cbd2fec566b6161e4dabcac2371ad1/package/settings/_colours-applied.scss#L50)

- This is required in [Gov UK React Button component](https://github.com/taranchauhan/govuk-react/blob/4ae37345ca04e91288699f560f48e3b7f684e0e6/components/button/src/index.js#L45)